### PR TITLE
Add optional tidy cleanup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # wpantimal
-Simple AnitMalware script for WP
+Simple AnitMalware script for WP.
+
+### Usage
+
+```
+./wp_core_check.sh [--repair] [--dry-run] [--force] [--append] [--log-file=FILE] [--wp-cli=PATH] [--tidy]
+```
+
+Use the `--tidy` flag to automatically remove inactive themes and plugins from each WordPress install. Combine with `--dry-run` to preview actions without making changes.


### PR DESCRIPTION
## Summary
- add `--tidy` option to wp_core_check.sh
- remove inactive themes and plugins when tidy mode enabled
- document the new flag in README

## Testing
- `bash -n wp_core_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_685f225619f0832a96c4eb9db1df1000