### PR TITLE
Add skip flags to WP CLI invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Simple AnitMalware script for WP.
 ```
 
 Use the `--tidy` flag to automatically remove inactive themes and plugins from each WordPress install. Combine with `--dry-run` to preview actions without making changes.
+
+The script automatically runs all WP-CLI commands with `--skip-plugins` and `--skip-themes` to prevent errors from faulty extensions.

--- a/wp_core_check.sh
+++ b/wp_core_check.sh
@@ -48,6 +48,9 @@ for arg in "$@"; do
     esac
 done
 
+# Ensure WP-CLI does not load plugins or themes to avoid errors
+WP_CLI="$WP_CLI --skip-plugins --skip-themes"
+
 if [[ -z "$LOG_FILE" ]]; then
     LOG_FILE="/var/www/clients/client1/core-checksums-report.log"
 fi


### PR DESCRIPTION
## Summary
- prevent plugin/theme code from loading by adding `--skip-plugins` and `--skip-themes`
- note the new behavior in README

## Testing
- `bash -n wp_core_check.sh`

------
https://chatgpt.com/codex/tasks/task_b_685f6212ad8c832a8b5a540e7ca661a8